### PR TITLE
Set cache expiration to 7 days

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
 const CACHE_NAME = 'antonio-ortega-v4';
+const CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 const urlsToCache = [
   '/',
   '/index.html',
@@ -10,6 +11,35 @@ const urlsToCache = [
   '/offline.html'
 ];
 
+// Helper function to check if a cached response is expired
+function isCacheExpired(cachedResponse) {
+  if (!cachedResponse) return true;
+  
+  const cacheDate = cachedResponse.headers.get('sw-cache-date');
+  if (!cacheDate) {
+    // If no cache date header, treat as expired to force refresh
+    return true;
+  }
+  
+  const cacheTime = parseInt(cacheDate, 10);
+  const now = Date.now();
+  const age = now - cacheTime;
+  
+  return age > CACHE_DURATION;
+}
+
+// Helper function to add cache timestamp to response
+function addCacheTimestamp(response) {
+  const headers = new Headers(response.headers);
+  headers.set('sw-cache-date', Date.now().toString());
+  
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: headers
+  });
+}
+
 // Install event - cache resources
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -18,34 +48,68 @@ self.addEventListener('install', (event) => {
         console.log('Opened cache');
         return cache.addAll(urlsToCache);
       })
+      .then(() => {
+        // Add timestamps to all cached items
+        return caches.open(CACHE_NAME).then((cache) => {
+          return cache.keys().then((requests) => {
+            return Promise.all(
+              requests.map((request) => {
+                return cache.match(request).then((response) => {
+                  if (response && !response.headers.get('sw-cache-date')) {
+                    return cache.put(request, addCacheTimestamp(response));
+                  }
+                });
+              })
+            );
+          });
+        });
+      })
       .catch((error) => {
         console.error('Cache installation failed:', error);
       })
   );
 });
 
-// Fetch event - serve from cache if available
+// Fetch event - serve from cache if available and not expired
 self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request)
-      .then((response) => {
-        // Return cached version if available
-        if (response) {
-          return response;
-        }
-        
-        // Clone the request because it's a stream and can only be consumed once
+      .then((cachedResponse) => {
         const fetchRequest = event.request.clone();
         
+        // If we have a cached response and it's not expired, serve it
+        if (cachedResponse && !isCacheExpired(cachedResponse)) {
+          // Update cache in background (stale-while-revalidate)
+          fetch(fetchRequest)
+            .then((response) => {
+              if (response && response.status === 200 && response.type === 'basic') {
+                const responseToCache = addCacheTimestamp(response.clone());
+                caches.open(CACHE_NAME).then((cache) => {
+                  cache.put(event.request, responseToCache);
+                });
+              }
+            })
+            .catch(() => {
+              // Network failed, but we already have cached content
+            });
+          
+          return cachedResponse;
+        }
+        
+        // Cache expired or not found, fetch fresh content
         return fetch(fetchRequest)
           .then((response) => {
             // Check if we received a valid response
             if (!response || response.status !== 200 || response.type !== 'basic') {
+              // If network fails but we have stale cache, serve it
+              if (cachedResponse) {
+                return cachedResponse;
+              }
               return response;
             }
             
             // Clone the response because it's a stream and can only be consumed once
-            const responseToCache = response.clone();
+            const responseToCache = addCacheTimestamp(response.clone());
             
             caches.open(CACHE_NAME)
               .then((cache) => {
@@ -55,6 +119,12 @@ self.addEventListener('fetch', (event) => {
             return response;
           })
           .catch(() => {
+            // Network request failed
+            if (cachedResponse) {
+              // Serve stale cache if available
+              return cachedResponse;
+            }
+            
             // If network request fails, return offline page for navigation requests
             if (event.request.mode === 'navigate') {
               return caches.match('/offline.html');


### PR DESCRIPTION
- Added CACHE_DURATION constant (7 days)
- Implemented cache expiration check using timestamp headers
- Updated fetch strategy to refresh expired cache (>7 days old)
- Added stale-while-revalidate pattern for better performance
- Cache now automatically refreshes after one week