### PR TITLE
Fix service worker causing reload loop in Docker development

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,18 +4,8 @@ import Head from 'next/head';
 
 class MyApp extends App {
   componentDidMount() {
-    // Register service worker for PWA functionality
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js')
-          .then((registration) => {
-            console.log('SW registered: ', registration);
-          })
-          .catch((registrationError) => {
-            console.log('SW registration failed: ', registrationError);
-          });
-      });
-    }
+    // Service worker registration is handled in _document.js
+    // Only registered in production to avoid conflicts with Next.js HMR in development
   }
 
   render() {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,41 +1,46 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
 export default function Document() {
+  // Only register service worker in production to avoid conflicts with Next.js HMR in development
+  const isProduction = process.env.NODE_ENV === 'production'
+  
   return (
     <Html lang="en">
       <Head />
       <body>
         <Main />
         <NextScript />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              if ('serviceWorker' in navigator) {
-                window.addEventListener('load', () => {
-                  navigator.serviceWorker.register('/sw.js')
-                    .then((registration) => {
-                      console.log('Service Worker registered successfully:', registration);
-                      
-                      // Check for updates
-                      registration.addEventListener('updatefound', () => {
-                        const newWorker = registration.installing;
-                        newWorker.addEventListener('statechange', () => {
-                          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                            console.log('New service worker available');
-                          }
+        {isProduction && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                if ('serviceWorker' in navigator) {
+                  window.addEventListener('load', () => {
+                    navigator.serviceWorker.register('/sw.js')
+                      .then((registration) => {
+                        console.log('Service Worker registered successfully:', registration);
+                        
+                        // Check for updates
+                        registration.addEventListener('updatefound', () => {
+                          const newWorker = registration.installing;
+                          newWorker.addEventListener('statechange', () => {
+                            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                              console.log('New service worker available');
+                            }
+                          });
                         });
+                      })
+                      .catch((registrationError) => {
+                        console.error('Service Worker registration failed:', registrationError);
                       });
-                    })
-                    .catch((registrationError) => {
-                      console.error('Service Worker registration failed:', registrationError);
-                    });
-                });
-              } else {
-                console.log('Service Worker not supported in this browser');
-              }
-            `,
-          }}
-        />
+                  });
+                } else {
+                  console.log('Service Worker not supported in this browser');
+                }
+              `,
+            }}
+          />
+        )}
       </body>
     </Html>
   )


### PR DESCRIPTION
- Remove duplicate service worker registration from _app.js
- Only register service worker in production mode
- Prevents conflicts with Next.js HMR in development
- Fixes infinite reload loop when running in Docker